### PR TITLE
Split tags by space, not comma

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -47,7 +47,7 @@ btnSave.addEventListener("click", (e) => {
     var tags = inputTags.value
         .toLowerCase()
         .replace(/\s+/g, " ")
-        .split(/\s*,\s*/g)
+        .split(/\s* \s*/g)
         .filter(tag => tag.trim() !== "")
         .map(tag => {
             return {


### PR DESCRIPTION
It's way more intuitive in my opinion, fixing uncertainties like in #9.

If not merged as-is, please provide it as an option.