### PR TITLE
Add hotkey command to toggle the popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -63,6 +63,15 @@
         }]
     },
 
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+F"
+            },
+            "description": "Show bookmark popup"
+        }
+    },
+
     "browser_specific_settings": {
         "gecko": {
             "id": "{c6e8bd66-ebb4-4b63-bd29-5ef59c795901}",


### PR DESCRIPTION
By default it's <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>, D was taken (to mimic bookmarks in Firefox), but this can be overridden by the user¹.

¹: https://support.mozilla.org/en-US/kb/manage-extension-shortcuts-firefox