### PR TITLE
Set browser icon to light if dark mode is on

### DIFF
--- a/js/background-script.js
+++ b/js/background-script.js
@@ -219,12 +219,22 @@ async function saveBookmark(tags) {
 
 async function updateIcon() {
     // Set initial icon
-    var runtimeUrl = await browser.runtime.getURL("/"),
-        icon = {path: {
-            16: "icons/action-default-16.png",
-            32: "icons/action-default-32.png",
-            64: "icons/action-default-64.png"
-        }};
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        accent = {path: {
+            16: "icons/action-light-16.png",
+            32: "icons/action-light-32.png",
+            64: "icons/action-light-64.png"
+        }}
+    } else {
+        accent = {path: {
+            16: "icons/action-dark-16.png",
+            32: "icons/action-dark-32.png",
+            64: "icons/action-dark-64.png"
+        }}
+    }
+
+    var runtimeUrl = await browser.runtime.getURL("/"), 
+        icon = accent;
     
     // Firefox allows using empty object as default icon.
     // This way, Firefox will use default_icon that defined in manifest.json


### PR DESCRIPTION
This PR allows Chrome to set the light icon when dark mode is enabled.
As we do not touch the manifest, the cross-browser compatibility is preserved.

<img width="382" alt="shiori-dark-mode" src="https://user-images.githubusercontent.com/2095991/83076715-57551400-a076-11ea-9078-9cd42daa0049.png">

Feel free to comment if you think there is a better way 🙂 

