### PR TITLE
feat: add custom search-engine to query shiori

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -76,5 +76,9 @@
         "gecko": {
             "id": "{8547b985-a7a0-408d-82d1-d185f8be1ff5}"
         }
+    },
+
+    "omnibox": {
+      "keyword": "@shiori"
     }
 }


### PR DESCRIPTION
It is now possible to query Shiori directly from the firefox search bar by simply prefixing the query with `@shiori`. This will trigger a shiori keyword search. It is also possible to search by tags, by prefixing words with `#`.

fixes: #58