### PR TITLE
Fix apiURL

### DIFF
--- a/js/background-script.js
+++ b/js/background-script.js
@@ -106,7 +106,9 @@ async function openLibraries() {
 async function removeBookmark() {
     const tab = await getCurrentTab();
     const config = await getExtensionConfig();
-    const apiURL = new URL(`${config.server}/api/bookmarks/ext`).toString();
+    const srvURL = new URL(config.server);
+    srvURL.pathname = srvURL.pathname.replace(/\/+$/, '') + '/';
+    const apiURL = new URL(`${srvURL}api/bookmarks/ext`).toString();
 
     const response = await fetch(apiURL, {
         method: "DELETE",
@@ -128,7 +130,9 @@ async function saveBookmark(tags) {
     const tab = await getCurrentTab();
     const config = await getExtensionConfig();
     const content = await getPageContent(tab);
-    const apiURL = new URL(`${config.server}/api/bookmarks/ext`).toString();
+    const srvURL = new URL(config.server);
+    srvURL.pathname = srvURL.pathname.replace(/\/+$/, '') + '/';
+    const apiURL = new URL(`${srvURL}api/bookmarks/ext`).toString();
 
     const response = await fetch(apiURL, {
         method: "POST",


### PR DESCRIPTION
If the `config.server = 'https://example.com/'`, the `apiURL` will be a wrong value `https://example.com//api/bookmarks/ext`.
This PR re-implements the logic of the previous version:
https://github.com/go-shiori/shiori-web-ext/blob/bf4835e04ed0c69b5f58e43ab32463304c337880/js/background-script.js#L150