### PR TITLE
feat: remember last used mode when opening popup (search/add)

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -100,16 +100,18 @@ function showStatusError(message, needsConfig = false) {
   }
 }
 
-function showMainInterface() {
+function showMainInterface(initialMode = 'search') {
   statusCheck.style.display = 'none';
   extensionReady = true;
-  switchToMode('search');
+  switchToMode(initialMode);
 }
 
 function switchToMode(mode) {
   if (!extensionReady) return;
   
   currentMode = mode;
+  browser.storage.local.set({ lastMode: mode });
+
   if (mode === 'search') {
     searchMode.style.display = 'block';
     addMode.style.display = 'none';
@@ -357,7 +359,9 @@ async function initializeExtension() {
     const status = await checkExtensionConfiguration();
     
     if (status.ready) {
-      showMainInterface();
+      const data = await browser.storage.local.get("lastMode");
+      const savedMode = data.lastMode || 'search';
+      showMainInterface(savedMode);
     } else {
       showStatusError(status.error, status.needsConfig);
     }


### PR DESCRIPTION
Allows the add-on to 'remember' whether you were in 'search' or 'add' mode the last time you clicked on the icon and opens to that view accordingly. This is helpful for people (like myself) who primarily use the extension to add links to Shiori.

Hope this is useful! I tested these changes locally in Firefox version 143.0.1. I'm not super well-versed in extension development, so please let me know if there's anything I can do to improve this PR. And thanks again for creating this add-on!